### PR TITLE
Fix compilation error on newer compiler

### DIFF
--- a/src/engine/common/math.hpp
+++ b/src/engine/common/math.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cmath>
 
 struct Math
 {

--- a/src/engine/common/transition.hpp
+++ b/src/engine/common/transition.hpp
@@ -140,7 +140,7 @@ private:
 	static float ratio(float t)
 	{
 		const float width(5.0f);
-		return 1.0f / (1.0f + std::expf(-(width*(2.0f*t - 1.0f))));
+		return 1.0f / (1.0f + std::exp(-(width*(2.0f*t - 1.0f))));
 	}
 
 	void restart()


### PR DESCRIPTION
On Ubuntu 21.10 using gcc version 11.2.0, project fails to compile.
Adding minor fixes to resolve it.